### PR TITLE
fix editor display "bodyParser deprecated"

### DIFF
--- a/cyberbrain-vsc/package.json
+++ b/cyberbrain-vsc/package.json
@@ -28,7 +28,6 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/body-parser": "^1.19.0",
 		"@types/express": "^4.17.11",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^7.0.2",
@@ -47,7 +46,6 @@
 	},
 	"dependencies": {
 		"@msgpack/msgpack": "^2.3.0",
-		"body-parser": "^1.19.0",
 		"express": "^4.17.1",
 		"google-auth-library": "^6.1.3",
 		"randomcolor": "^0.6.2",

--- a/cyberbrain-vsc/src/rpc_server.ts
+++ b/cyberbrain-vsc/src/rpc_server.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import * as express from "express";
-import * as bodyParser from "body-parser";
 import { openTraceGraph } from "./webview";
 import { isTestMode } from "./utils";
 import { decode } from "@msgpack/msgpack";
@@ -20,7 +19,7 @@ export class RpcServer {
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.server = express();
-    this.server.use(bodyParser.raw({ limit: "10GB" }));
+    this.server.use(express.raw({ limit: "10GB" }));
     this.interactions = new Interactions();
 
     this.server.post("/frame", (req, res) => {


### PR DESCRIPTION

I noticed three is a strikethrough on “bodyParser” and the editor display "bodyParser deprecated".

![bodyparser deprecated](https://user-images.githubusercontent.com/25732253/116528111-03018680-a90e-11eb-89d5-2a5045c525a2.png)

Then I read the source code of `express` and found it's used `body-parser`. Besides, `express` exported the `raw` function and it's equal to `body-parser` raw function.

![image](https://user-images.githubusercontent.com/25732253/116528597-9a66d980-a90e-11eb-9aaa-3c6abbf16b88.png)

So I think **we can use `express.raw` replace `bodyParser.raw`**, and remove the `body-parser` as dependence.
