### PR TITLE
Add function line number

### DIFF
--- a/cyberbrain-vsc/src/trace_graph.js
+++ b/cyberbrain-vsc/src/trace_graph.js
@@ -194,12 +194,12 @@ class TraceGraph {
       ctx.textAlign = "center";
       ctx.fillStyle = "#cfa138";
       ctx.fillText(
-        `${this.traceData.frameMetadata.frame_name}`,
+        `${this.traceData.frameMetadata.filename} line ${this.traceData.frameMetadata.defined_lineno}`,
         0,
         topNodePos.y - 45
       );
       ctx.fillText(
-        `${this.traceData.frameMetadata.filename} line ${this.traceData.frameMetadata.fn_lineno}`,
+        `${this.traceData.frameMetadata.frame_name}`,
         0,
         topNodePos.y - 30
       );

--- a/cyberbrain-vsc/src/trace_graph.js
+++ b/cyberbrain-vsc/src/trace_graph.js
@@ -194,7 +194,12 @@ class TraceGraph {
       ctx.textAlign = "center";
       ctx.fillStyle = "#cfa138";
       ctx.fillText(
-        `${this.traceData.frameMetadata.filename} ${this.traceData.frameMetadata.frame_name}`,
+        `${this.traceData.frameMetadata.frame_name}`,
+        0,
+        topNodePos.y - 45
+      );
+      ctx.fillText(
+        `${this.traceData.frameMetadata.filename} line ${this.traceData.frameMetadata.fn_lineno}`,
         0,
         topNodePos.y - 30
       );

--- a/cyberbrain/frame.py
+++ b/cyberbrain/frame.py
@@ -57,6 +57,7 @@ class Frame:
         frame_name: str,
         instructions: dict[int, Instruction],
         offset_to_lineno: dict[int, int],
+        fn_lineno: int,
     ):
         # ################### Frame attribute ####################
         self.filename = filename
@@ -65,6 +66,8 @@ class Frame:
         self.frame_id = frame_name
         self.instructions = instructions
         self.offset_to_lineno = offset_to_lineno
+        # Line where traced function is defined in filename
+        self.fn_lineno = fn_lineno
 
         self.value_stack = value_stack.create_value_stack()
 
@@ -87,7 +90,7 @@ class Frame:
 
     @property
     def metadata(self):
-        """The FrameLocater we defined initially. See https://git.io/Jtl68.
+        """Frame metadata sent to rpc server
 
         More fields to add:
         - int64 start_lineno  // Start line of the frame in filename.
@@ -102,6 +105,7 @@ class Frame:
             # Ideally the qualified name, at least use callable's name.
             "frame_name": self.frame_name,
             "filename": self.filename,
+            "fn_lineno": self.fn_lineno,
         }
 
     @property

--- a/cyberbrain/frame.py
+++ b/cyberbrain/frame.py
@@ -57,7 +57,7 @@ class Frame:
         frame_name: str,
         instructions: dict[int, Instruction],
         offset_to_lineno: dict[int, int],
-        fn_lineno: int,
+        defined_lineno: int,
     ):
         # ################### Frame attribute ####################
         self.filename = filename
@@ -67,7 +67,7 @@ class Frame:
         self.instructions = instructions
         self.offset_to_lineno = offset_to_lineno
         # Line where traced function is defined in filename
-        self.fn_lineno = fn_lineno
+        self.defined_lineno = defined_lineno
 
         self.value_stack = value_stack.create_value_stack()
 
@@ -105,7 +105,7 @@ class Frame:
             # Ideally the qualified name, at least use callable's name.
             "frame_name": self.frame_name,
             "filename": self.filename,
-            "fn_lineno": self.fn_lineno,
+            "defined_lineno": self.defined_lineno,
         }
 
     @property

--- a/cyberbrain/tracer.py
+++ b/cyberbrain/tracer.py
@@ -92,7 +92,7 @@ class Tracer:
             frame_name=frame_name,
             instructions=instructions,
             offset_to_lineno=utils.map_bytecode_offset_to_lineno(raw_frame),
-            fn_lineno=raw_frame.f_code.co_firstlineno,
+            defined_lineno=raw_frame.f_code.co_firstlineno,
         )
         FrameTree.add_frame(self.frame.frame_id, self.frame)
         self.frame_logger = logger.FrameLogger(

--- a/cyberbrain/tracer.py
+++ b/cyberbrain/tracer.py
@@ -92,6 +92,7 @@ class Tracer:
             frame_name=frame_name,
             instructions=instructions,
             offset_to_lineno=utils.map_bytecode_offset_to_lineno(raw_frame),
+            fn_lineno=raw_frame.f_code.co_firstlineno,
         )
         FrameTree.add_frame(self.frame.frame_id, self.frame)
         self.frame_logger = logger.FrameLogger(

--- a/test/data/py37/decorated_func.json
+++ b/test/data/py37/decorated_func.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
         "filename": "test_api_decorator.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py37/decorated_func.json
+++ b/test/data/py37/decorated_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
-        "filename": "test_api_decorator.py"
+        "filename": "test_api_decorator.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py37/decorated_func_enabled.json
+++ b/test/data/py37/decorated_func_enabled.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
         "filename": "test_api_disabled.py",
-        "fn_lineno": 15
+        "defined_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py37/decorated_func_enabled.json
+++ b/test/data/py37/decorated_func_enabled.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
-        "filename": "test_api_disabled.py"
+        "filename": "test_api_disabled.py",
+        "fn_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py37/func.json
+++ b/test/data/py37/func.json
@@ -3,7 +3,7 @@
         "frame_id": "func",
         "frame_name": "func",
         "filename": "test_api_state.py",
-        "fn_lineno": 19
+        "defined_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py37/func.json
+++ b/test/data/py37/func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "func",
         "frame_name": "func",
-        "filename": "test_api_state.py"
+        "filename": "test_api_state.py",
+        "fn_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py37/generator_function.json
+++ b/test/data/py37/generator_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "generator_function",
         "frame_name": "generator_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py37/generator_function.json
+++ b/test/data/py37/generator_function.json
@@ -3,7 +3,7 @@
         "frame_id": "generator_function",
         "frame_name": "generator_function",
         "filename": "test_generator.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py37/test_api_tracer.json
+++ b/test/data/py37/test_api_tracer.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
-        "filename": "test_api_tracer.py"
+        "filename": "test_api_tracer.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_api_tracer.json
+++ b/test/data/py37/test_api_tracer.json
@@ -3,7 +3,7 @@
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
         "filename": "test_api_tracer.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_attribute.json
+++ b/test/data/py37/test_attribute.json
@@ -3,7 +3,7 @@
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
         "filename": "test_attribute.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py37/test_attribute.json
+++ b/test/data/py37/test_attribute.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
-        "filename": "test_attribute.py"
+        "filename": "test_attribute.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py37/test_basic_try_except.json
+++ b/test/data/py37/test_basic_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py37/test_basic_try_except.json
+++ b/test/data/py37/test_basic_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py37/test_binary_operation.json
+++ b/test/data/py37/test_binary_operation.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
-        "filename": "test_binary.py"
+        "filename": "test_binary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_binary_operation.json
+++ b/test/data/py37/test_binary_operation.json
@@ -3,7 +3,7 @@
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
         "filename": "test_binary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_break_in_finally.json
+++ b/test/data/py37/test_break_in_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
         "filename": "test_block.py",
-        "fn_lineno": 53
+        "defined_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_break_in_finally.json
+++ b/test/data/py37/test_break_in_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_break_in_finally_with_exception.json
+++ b/test/data/py37/test_break_in_finally_with_exception.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
         "filename": "test_block.py",
-        "fn_lineno": 67
+        "defined_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_break_in_finally_with_exception.json
+++ b/test/data/py37/test_break_in_finally_with_exception.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_call.json
+++ b/test/data/py37/test_call.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_call",
         "frame_name": "test_call",
-        "filename": "test_call.py"
+        "filename": "test_call.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py37/test_call.json
+++ b/test/data/py37/test_call.json
@@ -3,7 +3,7 @@
         "frame_id": "test_call",
         "frame_name": "test_call",
         "filename": "test_call.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py37/test_closure.json
+++ b/test/data/py37/test_closure.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_closure",
         "frame_name": "test_closure",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_closure.json
+++ b/test/data/py37/test_closure.json
@@ -3,7 +3,7 @@
         "frame_id": "test_closure",
         "frame_name": "test_closure",
         "filename": "test_cellvar.py",
-        "fn_lineno": 25
+        "defined_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_container.json
+++ b/test/data/py37/test_container.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_container",
         "frame_name": "test_container",
-        "filename": "test_container.py"
+        "filename": "test_container.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_container.json
+++ b/test/data/py37/test_container.json
@@ -3,7 +3,7 @@
         "frame_id": "test_container",
         "frame_name": "test_container",
         "filename": "test_container.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_deref_func.json
+++ b/test/data/py37/test_deref_func.json
@@ -3,7 +3,7 @@
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
         "filename": "test_cellvar.py",
-        "fn_lineno": 8
+        "defined_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_deref_func.json
+++ b/test/data/py37/test_deref_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_existing_variable_emit_initial_value.json
+++ b/test/data/py37/test_existing_variable_emit_initial_value.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
-        "filename": "test_initial_value.py"
+        "filename": "test_initial_value.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py37/test_existing_variable_emit_initial_value.json
+++ b/test/data/py37/test_existing_variable_emit_initial_value.json
@@ -3,7 +3,7 @@
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
         "filename": "test_initial_value.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py37/test_for_loop.json
+++ b/test/data/py37/test_for_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
-        "filename": "test_for_loop.py"
+        "filename": "test_for_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_for_loop.json
+++ b/test/data/py37/test_for_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
         "filename": "test_for_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_hello.json
+++ b/test/data/py37/test_hello.json
@@ -3,7 +3,7 @@
         "frame_id": "test_hello",
         "frame_name": "test_hello",
         "filename": "test_hello.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py37/test_hello.json
+++ b/test/data/py37/test_hello.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_hello",
         "frame_name": "test_hello",
-        "filename": "test_hello.py"
+        "filename": "test_hello.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py37/test_inplace_operations.json
+++ b/test/data/py37/test_inplace_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
         "filename": "test_inplace.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py37/test_inplace_operations.json
+++ b/test/data/py37/test_inplace_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
-        "filename": "test_inplace.py"
+        "filename": "test_inplace.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py37/test_jump.json
+++ b/test/data/py37/test_jump.json
@@ -3,7 +3,7 @@
         "frame_id": "test_jump",
         "frame_name": "test_jump",
         "filename": "test_jump.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_jump.json
+++ b/test/data/py37/test_jump.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_jump",
         "frame_name": "test_jump",
-        "filename": "test_jump.py"
+        "filename": "test_jump.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_list_comprehension.json
+++ b/test/data/py37/test_list_comprehension.json
@@ -3,7 +3,7 @@
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
         "filename": "test_list_comp.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py37/test_list_comprehension.json
+++ b/test/data/py37/test_list_comprehension.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
-        "filename": "test_list_comp.py"
+        "filename": "test_list_comp.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py37/test_miscellaneous.json
+++ b/test/data/py37/test_miscellaneous.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
-        "filename": "test_miscellaneous.py"
+        "filename": "test_miscellaneous.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_miscellaneous.json
+++ b/test/data/py37/test_miscellaneous.json
@@ -3,7 +3,7 @@
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
         "filename": "test_miscellaneous.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_nested_loop.json
+++ b/test/data/py37/test_nested_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
-        "filename": "test_nested_loop.py"
+        "filename": "test_nested_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_nested_loop.json
+++ b/test/data/py37/test_nested_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
         "filename": "test_nested_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_nested_try_except.json
+++ b/test/data/py37/test_nested_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 23
+        "defined_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_nested_try_except.json
+++ b/test/data/py37/test_nested_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py37/test_numpy.json
+++ b/test/data/py37/test_numpy.json
@@ -3,7 +3,7 @@
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
         "filename": "test_numpy.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_numpy.json
+++ b/test/data/py37/test_numpy.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
-        "filename": "test_numpy.py"
+        "filename": "test_numpy.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py37/test_pandas.json
+++ b/test/data/py37/test_pandas.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
-        "filename": "test_pandas.py"
+        "filename": "test_pandas.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py37/test_pandas.json
+++ b/test/data/py37/test_pandas.json
@@ -3,7 +3,7 @@
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
         "filename": "test_pandas.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py37/test_ref_outside_inner.json
+++ b/test/data/py37/test_ref_outside_inner.json
@@ -3,7 +3,7 @@
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
         "filename": "test_ref_outside.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py37/test_ref_outside_inner.json
+++ b/test/data/py37/test_ref_outside_inner.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
-        "filename": "test_ref_outside.py"
+        "filename": "test_ref_outside.py",
+        "fn_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py37/test_repr.json
+++ b/test/data/py37/test_repr.json
@@ -3,7 +3,7 @@
         "frame_id": "test_repr",
         "frame_name": "test_repr",
         "filename": "test_to_json.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py37/test_repr.json
+++ b/test/data/py37/test_repr.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_repr",
         "frame_name": "test_repr",
-        "filename": "test_to_json.py"
+        "filename": "test_to_json.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py37/test_try_except_finally.json
+++ b/test/data/py37/test_try_except_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
         "filename": "test_block.py",
-        "fn_lineno": 38
+        "defined_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py37/test_try_except_finally.json
+++ b/test/data/py37/test_try_except_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py37/test_unary_operations.json
+++ b/test/data/py37/test_unary_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
         "filename": "test_unary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_unary_operations.json
+++ b/test/data/py37/test_unary_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
-        "filename": "test_unary.py"
+        "filename": "test_unary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_unpack.json
+++ b/test/data/py37/test_unpack.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
-        "filename": "test_unpack.py"
+        "filename": "test_unpack.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_unpack.json
+++ b/test/data/py37/test_unpack.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
         "filename": "test_unpack.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py37/test_while_loop.json
+++ b/test/data/py37/test_while_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
         "filename": "test_while_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_while_loop.json
+++ b/test/data/py37/test_while_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
-        "filename": "test_while_loop.py"
+        "filename": "test_while_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py37/test_with.json
+++ b/test/data/py37/test_with.json
@@ -3,7 +3,7 @@
         "frame_id": "test_with",
         "frame_name": "test_with",
         "filename": "test_with.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py37/test_with.json
+++ b/test/data/py37/test_with.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_with",
         "frame_name": "test_with",
-        "filename": "test_with.py"
+        "filename": "test_with.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py37/yield_from_function.json
+++ b/test/data/py37/yield_from_function.json
@@ -3,7 +3,7 @@
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
         "filename": "test_generator.py",
-        "fn_lineno": 73
+        "defined_lineno": 73
     },
     "identifiers": [
         "inner"

--- a/test/data/py37/yield_from_function.json
+++ b/test/data/py37/yield_from_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 73
     },
     "identifiers": [
         "inner"

--- a/test/data/py38/decorated_func.json
+++ b/test/data/py38/decorated_func.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
         "filename": "test_api_decorator.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py38/decorated_func.json
+++ b/test/data/py38/decorated_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
-        "filename": "test_api_decorator.py"
+        "filename": "test_api_decorator.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py38/decorated_func_enabled.json
+++ b/test/data/py38/decorated_func_enabled.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
         "filename": "test_api_disabled.py",
-        "fn_lineno": 15
+        "defined_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py38/decorated_func_enabled.json
+++ b/test/data/py38/decorated_func_enabled.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
-        "filename": "test_api_disabled.py"
+        "filename": "test_api_disabled.py",
+        "fn_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py38/func.json
+++ b/test/data/py38/func.json
@@ -3,7 +3,7 @@
         "frame_id": "func",
         "frame_name": "func",
         "filename": "test_api_state.py",
-        "fn_lineno": 19
+        "defined_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py38/func.json
+++ b/test/data/py38/func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "func",
         "frame_name": "func",
-        "filename": "test_api_state.py"
+        "filename": "test_api_state.py",
+        "fn_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py38/generator_function.json
+++ b/test/data/py38/generator_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "generator_function",
         "frame_name": "generator_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py38/generator_function.json
+++ b/test/data/py38/generator_function.json
@@ -3,7 +3,7 @@
         "frame_id": "generator_function",
         "frame_name": "generator_function",
         "filename": "test_generator.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py38/test_api_tracer.json
+++ b/test/data/py38/test_api_tracer.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
-        "filename": "test_api_tracer.py"
+        "filename": "test_api_tracer.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_api_tracer.json
+++ b/test/data/py38/test_api_tracer.json
@@ -3,7 +3,7 @@
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
         "filename": "test_api_tracer.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_attribute.json
+++ b/test/data/py38/test_attribute.json
@@ -3,7 +3,7 @@
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
         "filename": "test_attribute.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py38/test_attribute.json
+++ b/test/data/py38/test_attribute.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
-        "filename": "test_attribute.py"
+        "filename": "test_attribute.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py38/test_basic_try_except.json
+++ b/test/data/py38/test_basic_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py38/test_basic_try_except.json
+++ b/test/data/py38/test_basic_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py38/test_binary_operation.json
+++ b/test/data/py38/test_binary_operation.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
-        "filename": "test_binary.py"
+        "filename": "test_binary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_binary_operation.json
+++ b/test/data/py38/test_binary_operation.json
@@ -3,7 +3,7 @@
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
         "filename": "test_binary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_break_in_finally.json
+++ b/test/data/py38/test_break_in_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
         "filename": "test_block.py",
-        "fn_lineno": 53
+        "defined_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_break_in_finally.json
+++ b/test/data/py38/test_break_in_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_break_in_finally_with_exception.json
+++ b/test/data/py38/test_break_in_finally_with_exception.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
         "filename": "test_block.py",
-        "fn_lineno": 67
+        "defined_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_break_in_finally_with_exception.json
+++ b/test/data/py38/test_break_in_finally_with_exception.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_call.json
+++ b/test/data/py38/test_call.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_call",
         "frame_name": "test_call",
-        "filename": "test_call.py"
+        "filename": "test_call.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py38/test_call.json
+++ b/test/data/py38/test_call.json
@@ -3,7 +3,7 @@
         "frame_id": "test_call",
         "frame_name": "test_call",
         "filename": "test_call.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py38/test_closure.json
+++ b/test/data/py38/test_closure.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_closure",
         "frame_name": "test_closure",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_closure.json
+++ b/test/data/py38/test_closure.json
@@ -3,7 +3,7 @@
         "frame_id": "test_closure",
         "frame_name": "test_closure",
         "filename": "test_cellvar.py",
-        "fn_lineno": 25
+        "defined_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_container.json
+++ b/test/data/py38/test_container.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_container",
         "frame_name": "test_container",
-        "filename": "test_container.py"
+        "filename": "test_container.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_container.json
+++ b/test/data/py38/test_container.json
@@ -3,7 +3,7 @@
         "frame_id": "test_container",
         "frame_name": "test_container",
         "filename": "test_container.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_continue_in_finally.json
+++ b/test/data/py38/test_continue_in_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_continue_in_finally",
         "frame_name": "test_continue_in_finally",
-        "filename": "test_block_py38.py"
+        "filename": "test_block_py38.py",
+        "fn_lineno": 14
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_continue_in_finally.json
+++ b/test/data/py38/test_continue_in_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_continue_in_finally",
         "frame_name": "test_continue_in_finally",
         "filename": "test_block_py38.py",
-        "fn_lineno": 14
+        "defined_lineno": 14
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_continue_in_finally_with_exception.json
+++ b/test/data/py38/test_continue_in_finally_with_exception.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_continue_in_finally_with_exception",
         "frame_name": "test_continue_in_finally_with_exception",
-        "filename": "test_block_py38.py"
+        "filename": "test_block_py38.py",
+        "fn_lineno": 44
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_continue_in_finally_with_exception.json
+++ b/test/data/py38/test_continue_in_finally_with_exception.json
@@ -3,7 +3,7 @@
         "frame_id": "test_continue_in_finally_with_exception",
         "frame_name": "test_continue_in_finally_with_exception",
         "filename": "test_block_py38.py",
-        "fn_lineno": 44
+        "defined_lineno": 44
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_deref_func.json
+++ b/test/data/py38/test_deref_func.json
@@ -3,7 +3,7 @@
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
         "filename": "test_cellvar.py",
-        "fn_lineno": 8
+        "defined_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_deref_func.json
+++ b/test/data/py38/test_deref_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_existing_variable_emit_initial_value.json
+++ b/test/data/py38/test_existing_variable_emit_initial_value.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
-        "filename": "test_initial_value.py"
+        "filename": "test_initial_value.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py38/test_existing_variable_emit_initial_value.json
+++ b/test/data/py38/test_existing_variable_emit_initial_value.json
@@ -3,7 +3,7 @@
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
         "filename": "test_initial_value.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py38/test_for_loop.json
+++ b/test/data/py38/test_for_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
-        "filename": "test_for_loop.py"
+        "filename": "test_for_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_for_loop.json
+++ b/test/data/py38/test_for_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
         "filename": "test_for_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_hello.json
+++ b/test/data/py38/test_hello.json
@@ -3,7 +3,7 @@
         "frame_id": "test_hello",
         "frame_name": "test_hello",
         "filename": "test_hello.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py38/test_hello.json
+++ b/test/data/py38/test_hello.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_hello",
         "frame_name": "test_hello",
-        "filename": "test_hello.py"
+        "filename": "test_hello.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py38/test_inplace_operations.json
+++ b/test/data/py38/test_inplace_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
         "filename": "test_inplace.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py38/test_inplace_operations.json
+++ b/test/data/py38/test_inplace_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
-        "filename": "test_inplace.py"
+        "filename": "test_inplace.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py38/test_jump.json
+++ b/test/data/py38/test_jump.json
@@ -3,7 +3,7 @@
         "frame_id": "test_jump",
         "frame_name": "test_jump",
         "filename": "test_jump.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_jump.json
+++ b/test/data/py38/test_jump.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_jump",
         "frame_name": "test_jump",
-        "filename": "test_jump.py"
+        "filename": "test_jump.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_list_comprehension.json
+++ b/test/data/py38/test_list_comprehension.json
@@ -3,7 +3,7 @@
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
         "filename": "test_list_comp.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py38/test_list_comprehension.json
+++ b/test/data/py38/test_list_comprehension.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
-        "filename": "test_list_comp.py"
+        "filename": "test_list_comp.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py38/test_miscellaneous.json
+++ b/test/data/py38/test_miscellaneous.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
-        "filename": "test_miscellaneous.py"
+        "filename": "test_miscellaneous.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_miscellaneous.json
+++ b/test/data/py38/test_miscellaneous.json
@@ -3,7 +3,7 @@
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
         "filename": "test_miscellaneous.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_nested_loop.json
+++ b/test/data/py38/test_nested_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
-        "filename": "test_nested_loop.py"
+        "filename": "test_nested_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_nested_loop.json
+++ b/test/data/py38/test_nested_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
         "filename": "test_nested_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_nested_try_except.json
+++ b/test/data/py38/test_nested_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 23
+        "defined_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_nested_try_except.json
+++ b/test/data/py38/test_nested_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py38/test_numpy.json
+++ b/test/data/py38/test_numpy.json
@@ -3,7 +3,7 @@
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
         "filename": "test_numpy.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_numpy.json
+++ b/test/data/py38/test_numpy.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
-        "filename": "test_numpy.py"
+        "filename": "test_numpy.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py38/test_pandas.json
+++ b/test/data/py38/test_pandas.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
-        "filename": "test_pandas.py"
+        "filename": "test_pandas.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py38/test_pandas.json
+++ b/test/data/py38/test_pandas.json
@@ -3,7 +3,7 @@
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
         "filename": "test_pandas.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py38/test_ref_outside_inner.json
+++ b/test/data/py38/test_ref_outside_inner.json
@@ -3,7 +3,7 @@
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
         "filename": "test_ref_outside.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py38/test_ref_outside_inner.json
+++ b/test/data/py38/test_ref_outside_inner.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
-        "filename": "test_ref_outside.py"
+        "filename": "test_ref_outside.py",
+        "fn_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py38/test_repr.json
+++ b/test/data/py38/test_repr.json
@@ -3,7 +3,7 @@
         "frame_id": "test_repr",
         "frame_name": "test_repr",
         "filename": "test_to_json.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py38/test_repr.json
+++ b/test/data/py38/test_repr.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_repr",
         "frame_name": "test_repr",
-        "filename": "test_to_json.py"
+        "filename": "test_to_json.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py38/test_try_except_finally.json
+++ b/test/data/py38/test_try_except_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
         "filename": "test_block.py",
-        "fn_lineno": 38
+        "defined_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py38/test_try_except_finally.json
+++ b/test/data/py38/test_try_except_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py38/test_unary_operations.json
+++ b/test/data/py38/test_unary_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
         "filename": "test_unary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_unary_operations.json
+++ b/test/data/py38/test_unary_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
-        "filename": "test_unary.py"
+        "filename": "test_unary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_unpack.json
+++ b/test/data/py38/test_unpack.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
-        "filename": "test_unpack.py"
+        "filename": "test_unpack.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_unpack.json
+++ b/test/data/py38/test_unpack.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
         "filename": "test_unpack.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py38/test_while_loop.json
+++ b/test/data/py38/test_while_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
         "filename": "test_while_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_while_loop.json
+++ b/test/data/py38/test_while_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
-        "filename": "test_while_loop.py"
+        "filename": "test_while_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py38/test_with.json
+++ b/test/data/py38/test_with.json
@@ -3,7 +3,7 @@
         "frame_id": "test_with",
         "frame_name": "test_with",
         "filename": "test_with.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py38/test_with.json
+++ b/test/data/py38/test_with.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_with",
         "frame_name": "test_with",
-        "filename": "test_with.py"
+        "filename": "test_with.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py38/yield_from_function.json
+++ b/test/data/py38/yield_from_function.json
@@ -3,7 +3,7 @@
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
         "filename": "test_generator.py",
-        "fn_lineno": 73
+        "defined_lineno": 73
     },
     "identifiers": [
         "inner"

--- a/test/data/py38/yield_from_function.json
+++ b/test/data/py38/yield_from_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 73
     },
     "identifiers": [
         "inner"

--- a/test/data/py39/decorated_func.json
+++ b/test/data/py39/decorated_func.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
         "filename": "test_api_decorator.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py39/decorated_func.json
+++ b/test/data/py39/decorated_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func",
         "frame_name": "decorated_func",
-        "filename": "test_api_decorator.py"
+        "filename": "test_api_decorator.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "a",

--- a/test/data/py39/decorated_func_enabled.json
+++ b/test/data/py39/decorated_func_enabled.json
@@ -3,7 +3,7 @@
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
         "filename": "test_api_disabled.py",
-        "fn_lineno": 15
+        "defined_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py39/decorated_func_enabled.json
+++ b/test/data/py39/decorated_func_enabled.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "decorated_func_enabled",
         "frame_name": "decorated_func_enabled",
-        "filename": "test_api_disabled.py"
+        "filename": "test_api_disabled.py",
+        "fn_lineno": 15
     },
     "identifiers": [
         "a"

--- a/test/data/py39/func.json
+++ b/test/data/py39/func.json
@@ -3,7 +3,7 @@
         "frame_id": "func",
         "frame_name": "func",
         "filename": "test_api_state.py",
-        "fn_lineno": 19
+        "defined_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py39/func.json
+++ b/test/data/py39/func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "func",
         "frame_name": "func",
-        "filename": "test_api_state.py"
+        "filename": "test_api_state.py",
+        "fn_lineno": 19
     },
     "identifiers": [
         "b",

--- a/test/data/py39/generator_function.json
+++ b/test/data/py39/generator_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "generator_function",
         "frame_name": "generator_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py39/generator_function.json
+++ b/test/data/py39/generator_function.json
@@ -3,7 +3,7 @@
         "frame_id": "generator_function",
         "frame_name": "generator_function",
         "filename": "test_generator.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "count",

--- a/test/data/py39/test_api_tracer.json
+++ b/test/data/py39/test_api_tracer.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
-        "filename": "test_api_tracer.py"
+        "filename": "test_api_tracer.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_api_tracer.json
+++ b/test/data/py39/test_api_tracer.json
@@ -3,7 +3,7 @@
         "frame_id": "test_api_tracer",
         "frame_name": "test_api_tracer",
         "filename": "test_api_tracer.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_attribute.json
+++ b/test/data/py39/test_attribute.json
@@ -3,7 +3,7 @@
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
         "filename": "test_attribute.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py39/test_attribute.json
+++ b/test/data/py39/test_attribute.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_attribute",
         "frame_name": "test_attribute",
-        "filename": "test_attribute.py"
+        "filename": "test_attribute.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a2",

--- a/test/data/py39/test_basic_try_except.json
+++ b/test/data/py39/test_basic_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py39/test_basic_try_except.json
+++ b/test/data/py39/test_basic_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_basic_try_except",
         "frame_name": "test_basic_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 9
     },
     "identifiers": [],
     "loops": [],

--- a/test/data/py39/test_binary_operation.json
+++ b/test/data/py39/test_binary_operation.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
-        "filename": "test_binary.py"
+        "filename": "test_binary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_binary_operation.json
+++ b/test/data/py39/test_binary_operation.json
@@ -3,7 +3,7 @@
         "frame_id": "test_binary_operation",
         "frame_name": "test_binary_operation",
         "filename": "test_binary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_break_in_finally.json
+++ b/test/data/py39/test_break_in_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
         "filename": "test_block.py",
-        "fn_lineno": 53
+        "defined_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_break_in_finally.json
+++ b/test/data/py39/test_break_in_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally",
         "frame_name": "test_break_in_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 53
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_break_in_finally_with_exception.json
+++ b/test/data/py39/test_break_in_finally_with_exception.json
@@ -3,7 +3,7 @@
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
         "filename": "test_block.py",
-        "fn_lineno": 67
+        "defined_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_break_in_finally_with_exception.json
+++ b/test/data/py39/test_break_in_finally_with_exception.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_break_in_finally_with_exception",
         "frame_name": "test_break_in_finally_with_exception",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 67
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_call.json
+++ b/test/data/py39/test_call.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_call",
         "frame_name": "test_call",
-        "filename": "test_call.py"
+        "filename": "test_call.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py39/test_call.json
+++ b/test/data/py39/test_call.json
@@ -3,7 +3,7 @@
         "frame_id": "test_call",
         "frame_name": "test_call",
         "filename": "test_call.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "counter",

--- a/test/data/py39/test_closure.json
+++ b/test/data/py39/test_closure.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_closure",
         "frame_name": "test_closure",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_closure.json
+++ b/test/data/py39/test_closure.json
@@ -3,7 +3,7 @@
         "frame_id": "test_closure",
         "frame_name": "test_closure",
         "filename": "test_cellvar.py",
-        "fn_lineno": 25
+        "defined_lineno": 25
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_container.json
+++ b/test/data/py39/test_container.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_container",
         "frame_name": "test_container",
-        "filename": "test_container.py"
+        "filename": "test_container.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_container.json
+++ b/test/data/py39/test_container.json
@@ -3,7 +3,7 @@
         "frame_id": "test_container",
         "frame_name": "test_container",
         "filename": "test_container.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_continue_in_finally.json
+++ b/test/data/py39/test_continue_in_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_continue_in_finally",
         "frame_name": "test_continue_in_finally",
-        "filename": "test_block_py38.py"
+        "filename": "test_block_py38.py",
+        "fn_lineno": 14
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_continue_in_finally.json
+++ b/test/data/py39/test_continue_in_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_continue_in_finally",
         "frame_name": "test_continue_in_finally",
         "filename": "test_block_py38.py",
-        "fn_lineno": 14
+        "defined_lineno": 14
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_continue_in_finally_with_exception.json
+++ b/test/data/py39/test_continue_in_finally_with_exception.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_continue_in_finally_with_exception",
         "frame_name": "test_continue_in_finally_with_exception",
-        "filename": "test_block_py38.py"
+        "filename": "test_block_py38.py",
+        "fn_lineno": 44
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_continue_in_finally_with_exception.json
+++ b/test/data/py39/test_continue_in_finally_with_exception.json
@@ -3,7 +3,7 @@
         "frame_id": "test_continue_in_finally_with_exception",
         "frame_name": "test_continue_in_finally_with_exception",
         "filename": "test_block_py38.py",
-        "fn_lineno": 44
+        "defined_lineno": 44
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_deref_func.json
+++ b/test/data/py39/test_deref_func.json
@@ -3,7 +3,7 @@
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
         "filename": "test_cellvar.py",
-        "fn_lineno": 8
+        "defined_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_deref_func.json
+++ b/test/data/py39/test_deref_func.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_deref_func",
         "frame_name": "test_deref_func",
-        "filename": "test_cellvar.py"
+        "filename": "test_cellvar.py",
+        "fn_lineno": 8
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_existing_variable_emit_initial_value.json
+++ b/test/data/py39/test_existing_variable_emit_initial_value.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
-        "filename": "test_initial_value.py"
+        "filename": "test_initial_value.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py39/test_existing_variable_emit_initial_value.json
+++ b/test/data/py39/test_existing_variable_emit_initial_value.json
@@ -3,7 +3,7 @@
         "frame_id": "test_existing_variable_emit_initial_value",
         "frame_name": "test_existing_variable_emit_initial_value",
         "filename": "test_initial_value.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py39/test_for_loop.json
+++ b/test/data/py39/test_for_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
-        "filename": "test_for_loop.py"
+        "filename": "test_for_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_for_loop.json
+++ b/test/data/py39/test_for_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_for_loop",
         "frame_name": "test_for_loop",
         "filename": "test_for_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_hello.json
+++ b/test/data/py39/test_hello.json
@@ -3,7 +3,7 @@
         "frame_id": "test_hello",
         "frame_name": "test_hello",
         "filename": "test_hello.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py39/test_hello.json
+++ b/test/data/py39/test_hello.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_hello",
         "frame_name": "test_hello",
-        "filename": "test_hello.py"
+        "filename": "test_hello.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "x",

--- a/test/data/py39/test_inplace_operations.json
+++ b/test/data/py39/test_inplace_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
         "filename": "test_inplace.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py39/test_inplace_operations.json
+++ b/test/data/py39/test_inplace_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_inplace_operations",
         "frame_name": "test_inplace_operations",
-        "filename": "test_inplace.py"
+        "filename": "test_inplace.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a1",

--- a/test/data/py39/test_jump.json
+++ b/test/data/py39/test_jump.json
@@ -3,7 +3,7 @@
         "frame_id": "test_jump",
         "frame_name": "test_jump",
         "filename": "test_jump.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_jump.json
+++ b/test/data/py39/test_jump.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_jump",
         "frame_name": "test_jump",
-        "filename": "test_jump.py"
+        "filename": "test_jump.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_list_comprehension.json
+++ b/test/data/py39/test_list_comprehension.json
@@ -3,7 +3,7 @@
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
         "filename": "test_list_comp.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py39/test_list_comprehension.json
+++ b/test/data/py39/test_list_comprehension.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_list_comprehension",
         "frame_name": "test_list_comprehension",
-        "filename": "test_list_comp.py"
+        "filename": "test_list_comp.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "n",

--- a/test/data/py39/test_miscellaneous.json
+++ b/test/data/py39/test_miscellaneous.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
-        "filename": "test_miscellaneous.py"
+        "filename": "test_miscellaneous.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_miscellaneous.json
+++ b/test/data/py39/test_miscellaneous.json
@@ -3,7 +3,7 @@
         "frame_id": "test_miscellaneous",
         "frame_name": "test_miscellaneous",
         "filename": "test_miscellaneous.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_nested_loop.json
+++ b/test/data/py39/test_nested_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
-        "filename": "test_nested_loop.py"
+        "filename": "test_nested_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_nested_loop.json
+++ b/test/data/py39/test_nested_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_loop",
         "frame_name": "test_nested_loop",
         "filename": "test_nested_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_nested_try_except.json
+++ b/test/data/py39/test_nested_try_except.json
@@ -3,7 +3,7 @@
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
         "filename": "test_block.py",
-        "fn_lineno": 23
+        "defined_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_nested_try_except.json
+++ b/test/data/py39/test_nested_try_except.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_nested_try_except",
         "frame_name": "test_nested_try_except",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 23
     },
     "identifiers": [
         "a"

--- a/test/data/py39/test_numpy.json
+++ b/test/data/py39/test_numpy.json
@@ -3,7 +3,7 @@
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
         "filename": "test_numpy.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_numpy.json
+++ b/test/data/py39/test_numpy.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_numpy",
         "frame_name": "test_numpy",
-        "filename": "test_numpy.py"
+        "filename": "test_numpy.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "x"

--- a/test/data/py39/test_pandas.json
+++ b/test/data/py39/test_pandas.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
-        "filename": "test_pandas.py"
+        "filename": "test_pandas.py",
+        "fn_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py39/test_pandas.json
+++ b/test/data/py39/test_pandas.json
@@ -3,7 +3,7 @@
         "frame_id": "test_pandas",
         "frame_name": "test_pandas",
         "filename": "test_pandas.py",
-        "fn_lineno": 6
+        "defined_lineno": 6
     },
     "identifiers": [
         "baby_data_set",

--- a/test/data/py39/test_ref_outside_inner.json
+++ b/test/data/py39/test_ref_outside_inner.json
@@ -3,7 +3,7 @@
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
         "filename": "test_ref_outside.py",
-        "fn_lineno": 9
+        "defined_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py39/test_ref_outside_inner.json
+++ b/test/data/py39/test_ref_outside_inner.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_ref_outside_inner",
         "frame_name": "test_ref_outside_inner",
-        "filename": "test_ref_outside.py"
+        "filename": "test_ref_outside.py",
+        "fn_lineno": 9
     },
     "identifiers": [
         "f",

--- a/test/data/py39/test_repr.json
+++ b/test/data/py39/test_repr.json
@@ -3,7 +3,7 @@
         "frame_id": "test_repr",
         "frame_name": "test_repr",
         "filename": "test_to_json.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py39/test_repr.json
+++ b/test/data/py39/test_repr.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_repr",
         "frame_name": "test_repr",
-        "filename": "test_to_json.py"
+        "filename": "test_to_json.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "match",

--- a/test/data/py39/test_try_except_finally.json
+++ b/test/data/py39/test_try_except_finally.json
@@ -3,7 +3,7 @@
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
         "filename": "test_block.py",
-        "fn_lineno": 38
+        "defined_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py39/test_try_except_finally.json
+++ b/test/data/py39/test_try_except_finally.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_try_except_finally",
         "frame_name": "test_try_except_finally",
-        "filename": "test_block.py"
+        "filename": "test_block.py",
+        "fn_lineno": 38
     },
     "identifiers": [
         "b"

--- a/test/data/py39/test_unary_operations.json
+++ b/test/data/py39/test_unary_operations.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
         "filename": "test_unary.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_unary_operations.json
+++ b/test/data/py39/test_unary_operations.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unary_operations",
         "frame_name": "test_unary_operations",
-        "filename": "test_unary.py"
+        "filename": "test_unary.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_unpack.json
+++ b/test/data/py39/test_unpack.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
-        "filename": "test_unpack.py"
+        "filename": "test_unpack.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_unpack.json
+++ b/test/data/py39/test_unpack.json
@@ -3,7 +3,7 @@
         "frame_id": "test_unpack",
         "frame_name": "test_unpack",
         "filename": "test_unpack.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "a",

--- a/test/data/py39/test_while_loop.json
+++ b/test/data/py39/test_while_loop.json
@@ -3,7 +3,7 @@
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
         "filename": "test_while_loop.py",
-        "fn_lineno": 5
+        "defined_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_while_loop.json
+++ b/test/data/py39/test_while_loop.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_while_loop",
         "frame_name": "test_while_loop",
-        "filename": "test_while_loop.py"
+        "filename": "test_while_loop.py",
+        "fn_lineno": 5
     },
     "identifiers": [
         "i",

--- a/test/data/py39/test_with.json
+++ b/test/data/py39/test_with.json
@@ -3,7 +3,7 @@
         "frame_id": "test_with",
         "frame_name": "test_with",
         "filename": "test_with.py",
-        "fn_lineno": 4
+        "defined_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py39/test_with.json
+++ b/test/data/py39/test_with.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "test_with",
         "frame_name": "test_with",
-        "filename": "test_with.py"
+        "filename": "test_with.py",
+        "fn_lineno": 4
     },
     "identifiers": [
         "ContextManagerNoReturn",

--- a/test/data/py39/yield_from_function.json
+++ b/test/data/py39/yield_from_function.json
@@ -3,7 +3,7 @@
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
         "filename": "test_generator.py",
-        "fn_lineno": 73
+        "defined_lineno": 73
     },
     "identifiers": [
         "inner"

--- a/test/data/py39/yield_from_function.json
+++ b/test/data/py39/yield_from_function.json
@@ -2,7 +2,8 @@
     "metadata": {
         "frame_id": "yield_from_function",
         "frame_name": "yield_from_function",
-        "filename": "test_generator.py"
+        "filename": "test_generator.py",
+        "fn_lineno": 73
     },
     "identifiers": [
         "inner"


### PR DESCRIPTION
Addresses one element of #17

Sends the line number where the traced function is defined as a part of the metadata sent to the rpc server. The extension displays the traced functions's name on one line, and then the filename and line number on the line below it, all in the header.

![image](https://user-images.githubusercontent.com/17478849/117234652-69494600-adf3-11eb-952c-b31a96d90709.png)
