### PR TITLE
Treat exceptions as normal variables properly

### DIFF
--- a/test/data/py310/test_simple.json
+++ b/test/data/py310/test_simple.json
@@ -1,0 +1,246 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_simple",
+            "frame_name": "test_simple",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 3
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b",
+            "c"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 5,
+                "index": 0,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+                "type": "Binding"
+            },
+            {
+                "lineno": 7,
+                "index": 1,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "ImportError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 8,
+                "index": 2,
+                "offset": 38,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 9,
+                "index": 3,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:3",
+                "target": "c",
+                "value": "{}",
+                "repr": "AssertionError()",
+                "type": "Binding"
+            },
+            {
+                "lineno": 13,
+                "index": 4,
+                "offset": 72,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:4",
+                "target": "c",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 15,
+                "index": 5,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:5",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 16,
+                "index": 6,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:6",
+                "target": "b",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 17,
+                "index": 7,
+                "offset": 86,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:7",
+                "target": "c",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_simple:2": [
+                "test_simple:0"
+            ],
+            "test_simple:4": [
+                "test_simple:2"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 5,
+            "index": 0,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 7,
+            "index": 1,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ImportError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 8,
+            "index": 2,
+            "offset": 38,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 9,
+            "index": 3,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:3",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "AssertionError()",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 13,
+            "index": 4,
+            "offset": 72,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:4",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "b",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0,
+                            "b": 0,
+                            "c": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 15,
+            "index": 5,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:5",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 16,
+            "index": 6,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 17,
+            "index": 7,
+            "offset": 86,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:7",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py310/test_throw_catch.json
+++ b/test/data/py310/test_throw_catch.json
@@ -1,0 +1,282 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch",
+            "frame_name": "test_throw_catch",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 30
+        },
+        "identifiers": [
+            "b",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 32,
+                "index": 0,
+                "offset": 14,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 35,
+                "index": 1,
+                "offset": 26,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 36,
+                "index": 2,
+                "offset": 68,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:2",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 3,
+                "offset": 80,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:3",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 4,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:4",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 40,
+                "index": 5,
+                "offset": 96,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:5",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 6,
+                "offset": 104,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:6",
+                "target": "b",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 7,
+                "offset": 112,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:7",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 8,
+                "offset": 114,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:8",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 44,
+                "index": 9,
+                "offset": 136,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:9",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch:6": [
+                "test_throw_catch:5"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 32,
+            "index": 0,
+            "offset": 14,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 35,
+            "index": 1,
+            "offset": 26,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 36,
+            "index": 2,
+            "offset": 68,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:2",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 3,
+            "offset": 80,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 4,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:4",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 40,
+            "index": 5,
+            "offset": 96,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 6,
+            "offset": 104,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "a": 0,
+                            "e": 3
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 7,
+            "offset": 112,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:7",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 8,
+            "offset": 114,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:8",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 44,
+            "index": 9,
+            "offset": 136,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:9",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py310/test_throw_catch_custom.json
+++ b/test/data/py310/test_throw_catch_custom.json
@@ -1,0 +1,250 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch_custom",
+            "frame_name": "test_throw_catch_custom",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 62
+        },
+        "identifiers": [
+            "b",
+            "CustomException",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 67,
+                "index": 0,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": -1,
+                "index": 1,
+                "offset": 34,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:1",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 69,
+                "index": 2,
+                "offset": 40,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:2",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 70,
+                "index": 3,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:3",
+                "target": "e",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 4,
+                "offset": 90,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:4",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 5,
+                "offset": 98,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:5",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 6,
+                "offset": 100,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:6",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 76,
+                "index": 7,
+                "offset": 122,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:7",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch_custom:2": [
+                "test_throw_catch_custom:1"
+            ],
+            "test_throw_catch_custom:4": [
+                "test_throw_catch_custom:3"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 67,
+            "index": 0,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": -1,
+            "index": 1,
+            "offset": 34,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:1",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 69,
+            "index": 2,
+            "offset": 40,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:2",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 70,
+            "index": 3,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 4,
+            "offset": 90,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:4",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0,
+                            "a": 0,
+                            "e": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 5,
+            "offset": 98,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 6,
+            "offset": 100,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:6",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 76,
+            "index": 7,
+            "offset": 122,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:7",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py310/test_throw_custom_inner.json
+++ b/test/data/py310/test_throw_custom_inner.json
@@ -1,0 +1,168 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_custom_inner",
+            "frame_name": "test_throw_custom_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 52
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": -1,
+                "index": 0,
+                "offset": 4,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 54,
+                "index": 1,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 55,
+                "index": 2,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 56,
+                "index": 3,
+                "offset": 24,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:3",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 53,
+                "index": 4,
+                "offset": 56,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:4",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_custom:1": [
+                "test_throw_custom:0"
+            ],
+            "test_throw_custom:2": [
+                "test_throw_custom:1"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": -1,
+            "index": 0,
+            "offset": 4,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 54,
+            "index": 1,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 55,
+            "index": 2,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "a",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 56,
+            "index": 3,
+            "offset": 24,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:3",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 53,
+            "index": 4,
+            "offset": 56,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:4",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py310/test_throw_inner.json
+++ b/test/data/py310/test_throw_inner.json
@@ -1,0 +1,66 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_inner",
+            "frame_name": "test_throw_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 22
+        },
+        "identifiers": [
+            "a"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 24,
+                "index": 0,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:0",
+                "target": "a",
+                "value": "{}",
+                "repr": "ZeroDivisionError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 23,
+                "index": 1,
+                "offset": 50,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:1",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {}
+    },
+    "tracer.events": [
+        {
+            "lineno": 24,
+            "index": 0,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:0",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ZeroDivisionError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 23,
+            "index": 1,
+            "offset": 50,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:1",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py37/test_simple.json
+++ b/test/data/py37/test_simple.json
@@ -1,0 +1,246 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_simple",
+            "frame_name": "test_simple",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 3
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b",
+            "c"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 5,
+                "index": 0,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+                "type": "Binding"
+            },
+            {
+                "lineno": 7,
+                "index": 1,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "ImportError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 8,
+                "index": 2,
+                "offset": 38,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 9,
+                "index": 3,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:3",
+                "target": "c",
+                "value": "{}",
+                "repr": "AssertionError()",
+                "type": "Binding"
+            },
+            {
+                "lineno": 13,
+                "index": 4,
+                "offset": 72,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:4",
+                "target": "c",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 15,
+                "index": 5,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:5",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 16,
+                "index": 6,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:6",
+                "target": "b",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 17,
+                "index": 7,
+                "offset": 86,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:7",
+                "target": "c",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_simple:2": [
+                "test_simple:0"
+            ],
+            "test_simple:4": [
+                "test_simple:2"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 5,
+            "index": 0,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 7,
+            "index": 1,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ImportError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 8,
+            "index": 2,
+            "offset": 38,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 9,
+            "index": 3,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:3",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "AssertionError()",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 13,
+            "index": 4,
+            "offset": 72,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:4",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "b",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0,
+                            "b": 0,
+                            "c": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 15,
+            "index": 5,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:5",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 16,
+            "index": 6,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 17,
+            "index": 7,
+            "offset": 86,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:7",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py37/test_throw_catch.json
+++ b/test/data/py37/test_throw_catch.json
@@ -1,0 +1,282 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch",
+            "frame_name": "test_throw_catch",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 30
+        },
+        "identifiers": [
+            "b",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 32,
+                "index": 0,
+                "offset": 14,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 35,
+                "index": 1,
+                "offset": 26,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 36,
+                "index": 2,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:2",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 3,
+                "offset": 100,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:3",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 4,
+                "offset": 102,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:4",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 40,
+                "index": 5,
+                "offset": 126,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:5",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 6,
+                "offset": 134,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:6",
+                "target": "b",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 7,
+                "offset": 142,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:7",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 8,
+                "offset": 144,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:8",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 44,
+                "index": 9,
+                "offset": 162,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:9",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch:6": [
+                "test_throw_catch:5"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 32,
+            "index": 0,
+            "offset": 14,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 35,
+            "index": 1,
+            "offset": 26,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 36,
+            "index": 2,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:2",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 3,
+            "offset": 100,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 4,
+            "offset": 102,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:4",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 40,
+            "index": 5,
+            "offset": 126,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 6,
+            "offset": 134,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "a": 0,
+                            "e": 3
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 7,
+            "offset": 142,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:7",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 8,
+            "offset": 144,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:8",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 44,
+            "index": 9,
+            "offset": 162,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:9",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py37/test_throw_catch_custom.json
+++ b/test/data/py37/test_throw_catch_custom.json
@@ -1,0 +1,250 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch_custom",
+            "frame_name": "test_throw_catch_custom",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 62
+        },
+        "identifiers": [
+            "b",
+            "CustomException",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 67,
+                "index": 0,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": -1,
+                "index": 1,
+                "offset": 34,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:1",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 69,
+                "index": 2,
+                "offset": 40,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:2",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 70,
+                "index": 3,
+                "offset": 98,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:3",
+                "target": "e",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 4,
+                "offset": 106,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:4",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 5,
+                "offset": 114,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:5",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 6,
+                "offset": 116,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:6",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 76,
+                "index": 7,
+                "offset": 134,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:7",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch_custom:2": [
+                "test_throw_catch_custom:1"
+            ],
+            "test_throw_catch_custom:4": [
+                "test_throw_catch_custom:3"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 67,
+            "index": 0,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": -1,
+            "index": 1,
+            "offset": 34,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:1",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 69,
+            "index": 2,
+            "offset": 40,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:2",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 70,
+            "index": 3,
+            "offset": 98,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 4,
+            "offset": 106,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:4",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0,
+                            "a": 0,
+                            "e": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 5,
+            "offset": 114,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 6,
+            "offset": 116,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:6",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 76,
+            "index": 7,
+            "offset": 134,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:7",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py37/test_throw_custom_inner.json
+++ b/test/data/py37/test_throw_custom_inner.json
@@ -1,0 +1,168 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_custom_inner",
+            "frame_name": "test_throw_custom_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 52
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": -1,
+                "index": 0,
+                "offset": 4,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 54,
+                "index": 1,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 55,
+                "index": 2,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 56,
+                "index": 3,
+                "offset": 24,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:3",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 58,
+                "index": 4,
+                "offset": 50,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:4",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_custom:1": [
+                "test_throw_custom:0"
+            ],
+            "test_throw_custom:2": [
+                "test_throw_custom:1"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": -1,
+            "index": 0,
+            "offset": 4,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 54,
+            "index": 1,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 55,
+            "index": 2,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "a",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 56,
+            "index": 3,
+            "offset": 24,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:3",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 58,
+            "index": 4,
+            "offset": 50,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:4",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py37/test_throw_inner.json
+++ b/test/data/py37/test_throw_inner.json
@@ -1,0 +1,66 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_inner",
+            "frame_name": "test_throw_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 22
+        },
+        "identifiers": [
+            "a"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 24,
+                "index": 0,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:0",
+                "target": "a",
+                "value": "{}",
+                "repr": "ZeroDivisionError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 26,
+                "index": 1,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:1",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {}
+    },
+    "tracer.events": [
+        {
+            "lineno": 24,
+            "index": 0,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:0",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ZeroDivisionError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 26,
+            "index": 1,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:1",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py38/test_simple.json
+++ b/test/data/py38/test_simple.json
@@ -1,0 +1,246 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_simple",
+            "frame_name": "test_simple",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 3
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b",
+            "c"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 5,
+                "index": 0,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+                "type": "Binding"
+            },
+            {
+                "lineno": 7,
+                "index": 1,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "ImportError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 8,
+                "index": 2,
+                "offset": 38,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 9,
+                "index": 3,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:3",
+                "target": "c",
+                "value": "{}",
+                "repr": "AssertionError()",
+                "type": "Binding"
+            },
+            {
+                "lineno": 13,
+                "index": 4,
+                "offset": 72,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:4",
+                "target": "c",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 15,
+                "index": 5,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:5",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 16,
+                "index": 6,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:6",
+                "target": "b",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 17,
+                "index": 7,
+                "offset": 86,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:7",
+                "target": "c",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_simple:2": [
+                "test_simple:0"
+            ],
+            "test_simple:4": [
+                "test_simple:2"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 5,
+            "index": 0,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 7,
+            "index": 1,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ImportError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 8,
+            "index": 2,
+            "offset": 38,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 9,
+            "index": 3,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:3",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "AssertionError()",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 13,
+            "index": 4,
+            "offset": 72,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:4",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "b",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0,
+                            "b": 0,
+                            "c": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 15,
+            "index": 5,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:5",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 16,
+            "index": 6,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 17,
+            "index": 7,
+            "offset": 86,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:7",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py38/test_throw_catch.json
+++ b/test/data/py38/test_throw_catch.json
@@ -1,0 +1,282 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch",
+            "frame_name": "test_throw_catch",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 30
+        },
+        "identifiers": [
+            "b",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 32,
+                "index": 0,
+                "offset": 14,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 35,
+                "index": 1,
+                "offset": 26,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 36,
+                "index": 2,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:2",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 3,
+                "offset": 100,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:3",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 4,
+                "offset": 102,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:4",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 40,
+                "index": 5,
+                "offset": 126,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:5",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 6,
+                "offset": 134,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:6",
+                "target": "b",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 7,
+                "offset": 142,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:7",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 8,
+                "offset": 144,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:8",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 44,
+                "index": 9,
+                "offset": 162,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:9",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch:6": [
+                "test_throw_catch:5"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 32,
+            "index": 0,
+            "offset": 14,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 35,
+            "index": 1,
+            "offset": 26,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 36,
+            "index": 2,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:2",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 3,
+            "offset": 100,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 4,
+            "offset": 102,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:4",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 40,
+            "index": 5,
+            "offset": 126,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 6,
+            "offset": 134,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "a": 0,
+                            "e": 3
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 7,
+            "offset": 142,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:7",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 8,
+            "offset": 144,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:8",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 44,
+            "index": 9,
+            "offset": 162,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:9",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py38/test_throw_catch_custom.json
+++ b/test/data/py38/test_throw_catch_custom.json
@@ -1,0 +1,250 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch_custom",
+            "frame_name": "test_throw_catch_custom",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 62
+        },
+        "identifiers": [
+            "b",
+            "CustomException",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 67,
+                "index": 0,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": -1,
+                "index": 1,
+                "offset": 34,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:1",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 69,
+                "index": 2,
+                "offset": 40,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:2",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 70,
+                "index": 3,
+                "offset": 98,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:3",
+                "target": "e",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 4,
+                "offset": 106,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:4",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 5,
+                "offset": 114,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:5",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 6,
+                "offset": 116,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:6",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 76,
+                "index": 7,
+                "offset": 134,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:7",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch_custom:2": [
+                "test_throw_catch_custom:1"
+            ],
+            "test_throw_catch_custom:4": [
+                "test_throw_catch_custom:3"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 67,
+            "index": 0,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": -1,
+            "index": 1,
+            "offset": 34,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:1",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 69,
+            "index": 2,
+            "offset": 40,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:2",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 70,
+            "index": 3,
+            "offset": 98,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 4,
+            "offset": 106,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:4",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0,
+                            "a": 0,
+                            "e": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 5,
+            "offset": 114,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 6,
+            "offset": 116,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:6",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 76,
+            "index": 7,
+            "offset": 134,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:7",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py38/test_throw_custom_inner.json
+++ b/test/data/py38/test_throw_custom_inner.json
@@ -1,0 +1,168 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_custom_inner",
+            "frame_name": "test_throw_custom_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 52
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": -1,
+                "index": 0,
+                "offset": 4,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 54,
+                "index": 1,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 55,
+                "index": 2,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 56,
+                "index": 3,
+                "offset": 24,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:3",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 58,
+                "index": 4,
+                "offset": 50,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:4",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_custom:1": [
+                "test_throw_custom:0"
+            ],
+            "test_throw_custom:2": [
+                "test_throw_custom:1"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": -1,
+            "index": 0,
+            "offset": 4,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 54,
+            "index": 1,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 55,
+            "index": 2,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "a",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 56,
+            "index": 3,
+            "offset": 24,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:3",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 58,
+            "index": 4,
+            "offset": 50,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:4",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py38/test_throw_inner.json
+++ b/test/data/py38/test_throw_inner.json
@@ -1,0 +1,66 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_inner",
+            "frame_name": "test_throw_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 22
+        },
+        "identifiers": [
+            "a"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 24,
+                "index": 0,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:0",
+                "target": "a",
+                "value": "{}",
+                "repr": "ZeroDivisionError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 26,
+                "index": 1,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:1",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {}
+    },
+    "tracer.events": [
+        {
+            "lineno": 24,
+            "index": 0,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:0",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ZeroDivisionError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 26,
+            "index": 1,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:1",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py39/test_simple.json
+++ b/test/data/py39/test_simple.json
@@ -1,0 +1,246 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_simple",
+            "frame_name": "test_simple",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 3
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b",
+            "c"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 5,
+                "index": 0,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+                "type": "Binding"
+            },
+            {
+                "lineno": 7,
+                "index": 1,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "ImportError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 8,
+                "index": 2,
+                "offset": 38,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 9,
+                "index": 3,
+                "offset": 44,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:3",
+                "target": "c",
+                "value": "{}",
+                "repr": "AssertionError()",
+                "type": "Binding"
+            },
+            {
+                "lineno": 13,
+                "index": 4,
+                "offset": 72,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:4",
+                "target": "c",
+                "value": "{}",
+                "repr": "CustomException('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 15,
+                "index": 5,
+                "offset": 82,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:5",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 16,
+                "index": 6,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:6",
+                "target": "b",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 17,
+                "index": 7,
+                "offset": 86,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_simple:7",
+                "target": "c",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_simple:2": [
+                "test_simple:0"
+            ],
+            "test_simple:4": [
+                "test_simple:2"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 5,
+            "index": 0,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_simple.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...le.<locals>.CustomException'>",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 7,
+            "index": 1,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ImportError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 8,
+            "index": 2,
+            "offset": 38,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 9,
+            "index": 3,
+            "offset": 44,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:3",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "AssertionError()",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 13,
+            "index": 4,
+            "offset": 72,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:4",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('B')",
+            "sources": [
+                {
+                    "name": "b",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0,
+                            "b": 0,
+                            "c": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 15,
+            "index": 5,
+            "offset": 82,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:5",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 16,
+            "index": 6,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 17,
+            "index": 7,
+            "offset": 86,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_simple:7",
+            "target": {
+                "name": "c",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py39/test_throw_catch.json
+++ b/test/data/py39/test_throw_catch.json
@@ -1,0 +1,282 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch",
+            "frame_name": "test_throw_catch",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 30
+        },
+        "identifiers": [
+            "b",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 32,
+                "index": 0,
+                "offset": 14,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 35,
+                "index": 1,
+                "offset": 26,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 36,
+                "index": 2,
+                "offset": 84,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:2",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 3,
+                "offset": 108,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:3",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 40,
+                "index": 4,
+                "offset": 110,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:4",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 40,
+                "index": 5,
+                "offset": 128,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:5",
+                "target": "e",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 6,
+                "offset": 136,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:6",
+                "target": "b",
+                "value": "{}",
+                "repr": "RuntimeError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 7,
+                "offset": 144,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:7",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 42,
+                "index": 8,
+                "offset": 146,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:8",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 44,
+                "index": 9,
+                "offset": 168,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch:9",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch:6": [
+                "test_throw_catch:5"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 32,
+            "index": 0,
+            "offset": 14,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 35,
+            "index": 1,
+            "offset": 26,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 36,
+            "index": 2,
+            "offset": 84,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:2",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 3,
+            "offset": 108,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 40,
+            "index": 4,
+            "offset": 110,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:4",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 40,
+            "index": 5,
+            "offset": 128,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 6,
+            "offset": 136,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:6",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "RuntimeError('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "a": 0,
+                            "e": 3
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 7,
+            "offset": 144,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:7",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 42,
+            "index": 8,
+            "offset": 146,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:8",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 44,
+            "index": 9,
+            "offset": 168,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch:9",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py39/test_throw_catch_custom.json
+++ b/test/data/py39/test_throw_catch_custom.json
@@ -1,0 +1,250 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_catch_custom",
+            "frame_name": "test_throw_catch_custom",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 62
+        },
+        "identifiers": [
+            "b",
+            "CustomException",
+            "a",
+            "e"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 67,
+                "index": 0,
+                "offset": 30,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:0",
+                "target": "b",
+                "value": "{}",
+                "repr": "TypeError('B')",
+                "type": "Binding"
+            },
+            {
+                "lineno": -1,
+                "index": 1,
+                "offset": 34,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:1",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 69,
+                "index": 2,
+                "offset": 40,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:2",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 70,
+                "index": 3,
+                "offset": 98,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:3",
+                "target": "e",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 4,
+                "offset": 106,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:4",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 5,
+                "offset": 114,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:5",
+                "target": "e",
+                "value": "null",
+                "repr": "None",
+                "type": "Binding"
+            },
+            {
+                "lineno": 74,
+                "index": 6,
+                "offset": 116,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:6",
+                "target": "e",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 76,
+                "index": 7,
+                "offset": 138,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_catch_custom:7",
+                "target": "b",
+                "type": "Deletion"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_catch_custom:2": [
+                "test_throw_catch_custom:1"
+            ],
+            "test_throw_catch_custom:4": [
+                "test_throw_catch_custom:3"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": 67,
+            "index": 0,
+            "offset": 30,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:0",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "TypeError('B')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": -1,
+            "index": 1,
+            "offset": 34,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:1",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_catch_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 69,
+            "index": 2,
+            "offset": 40,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:2",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 70,
+            "index": 3,
+            "offset": 98,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:3",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 4,
+            "offset": 106,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:4",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "e",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "b": 0,
+                            "CustomException": 0,
+                            "a": 0,
+                            "e": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 5,
+            "offset": 114,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:5",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 74,
+            "index": 6,
+            "offset": 116,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:6",
+            "target": {
+                "name": "e",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 76,
+            "index": 7,
+            "offset": 138,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_catch_custom:7",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        }
+    ]
+}

--- a/test/data/py39/test_throw_custom_inner.json
+++ b/test/data/py39/test_throw_custom_inner.json
@@ -1,0 +1,168 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_custom_inner",
+            "frame_name": "test_throw_custom_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 52
+        },
+        "identifiers": [
+            "CustomException",
+            "a",
+            "b"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": -1,
+                "index": 0,
+                "offset": 4,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:0",
+                "target": "CustomException",
+                "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+                "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+                "type": "InitialValue"
+            },
+            {
+                "lineno": 54,
+                "index": 1,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:1",
+                "target": "a",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 55,
+                "index": 2,
+                "offset": 22,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:2",
+                "target": "b",
+                "value": "{}",
+                "repr": "CustomException('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 56,
+                "index": 3,
+                "offset": 24,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:3",
+                "target": "a",
+                "type": "Deletion"
+            },
+            {
+                "lineno": 58,
+                "index": 4,
+                "offset": 70,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw_custom:4",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {
+            "test_throw_custom:1": [
+                "test_throw_custom:0"
+            ],
+            "test_throw_custom:2": [
+                "test_throw_custom:1"
+            ]
+        }
+    },
+    "tracer.events": [
+        {
+            "lineno": -1,
+            "index": 0,
+            "offset": 4,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:0",
+            "target": {
+                "name": "CustomException",
+                "snapshot": null
+            },
+            "value": "{\"py/type\":\"test_normal_exceptions.test_throw_custom.<locals>.CustomException\"}",
+            "repr": "<class 'test_normal_exceptio...om.<locals>.CustomException'>",
+            "__class__": "InitialValue"
+        },
+        {
+            "lineno": 54,
+            "index": 1,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:1",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "CustomException",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 55,
+            "index": 2,
+            "offset": 22,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:2",
+            "target": {
+                "name": "b",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "CustomException('A')",
+            "sources": [
+                {
+                    "name": "a",
+                    "snapshot": {
+                        "location": null,
+                        "events_pointer": {
+                            "CustomException": 0,
+                            "a": 0
+                        }
+                    }
+                }
+            ],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 56,
+            "index": 3,
+            "offset": 24,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:3",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "__class__": "Deletion"
+        },
+        {
+            "lineno": 58,
+            "index": 4,
+            "offset": 70,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw_custom:4",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/data/py39/test_throw_inner.json
+++ b/test/data/py39/test_throw_inner.json
@@ -1,0 +1,66 @@
+{
+    "response": {
+        "metadata": {
+            "frame_id": "test_throw_inner",
+            "frame_name": "test_throw_inner",
+            "filename": "test_normal_exceptions.py",
+            "defined_lineno": 22
+        },
+        "identifiers": [
+            "a"
+        ],
+        "loops": [],
+        "events": [
+            {
+                "lineno": 24,
+                "index": 0,
+                "offset": 18,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:0",
+                "target": "a",
+                "value": "{}",
+                "repr": "ZeroDivisionError('A')",
+                "type": "Binding"
+            },
+            {
+                "lineno": 26,
+                "index": 1,
+                "offset": 64,
+                "filename": "test_normal_exceptions.py",
+                "id": "test_throw:1",
+                "value": "null",
+                "repr": "None",
+                "type": "Return"
+            }
+        ],
+        "tracingResult": {}
+    },
+    "tracer.events": [
+        {
+            "lineno": 24,
+            "index": 0,
+            "offset": 18,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:0",
+            "target": {
+                "name": "a",
+                "snapshot": null
+            },
+            "value": "{}",
+            "repr": "ZeroDivisionError('A')",
+            "sources": [],
+            "__class__": "Binding"
+        },
+        {
+            "lineno": 26,
+            "index": 1,
+            "offset": 64,
+            "filename": "test_normal_exceptions.py",
+            "id": "test_throw:1",
+            "value": "null",
+            "repr": "None",
+            "sources": [],
+            "__class__": "Return"
+        }
+    ]
+}

--- a/test/test_normal_exceptions.py
+++ b/test/test_normal_exceptions.py
@@ -1,0 +1,84 @@
+import pytest
+
+
+def test_simple(tracer, check_golden_file):
+    tracer.start()
+
+    class CustomException(Exception):
+        pass
+
+    a = ImportError("A")
+    b = CustomException("B")
+    c = AssertionError()
+    print(a)
+    print(b)
+    print(c)
+    c = b
+    print(c)
+    del a
+    del b
+    del c
+    tracer.stop()
+
+
+def test_throw(trace, check_golden_file):
+    @trace
+    def test_throw_inner():
+        with pytest.raises(ZeroDivisionError):
+            a = ZeroDivisionError("A")
+            print(a)
+            raise a
+
+    test_throw_inner()
+
+
+def test_throw_catch(tracer, check_golden_file):
+    tracer.start()
+    b = TypeError("B")
+    try:
+        try:
+            a = RuntimeError("A")
+            raise a
+        except b.__class__ as e:
+            raise e
+        except RuntimeError as e:
+            raise e
+    except Exception as e:
+        b = e
+    print(b)
+    del b
+    tracer.stop()
+
+
+def test_throw_custom(trace, check_golden_file):
+    class CustomException(Exception):
+        pass
+
+    @trace
+    def test_throw_custom_inner():
+        with pytest.raises(CustomException):
+            a = CustomException("A")
+            b = a
+            del a
+            print(b)
+            raise b
+
+    test_throw_custom_inner()
+
+
+def test_throw_catch_custom(tracer, check_golden_file):
+    class CustomException(Exception):
+        pass
+
+    tracer.start()
+    b = TypeError("B")
+    try:
+        a = CustomException("A")
+        raise a
+    except b.__class__ as e:
+        raise e
+    except CustomException as e:
+        b = e
+    print(b)
+    del b
+    tracer.stop()


### PR DESCRIPTION
Fixes #147 

Use `SymbolWithCustomValueStackItem` class to allow exceptions to be treated as normal variables.